### PR TITLE
修改选项逻辑

### DIFF
--- a/install-release.sh
+++ b/install-release.sh
@@ -194,7 +194,7 @@ judgment_parameters() {
       'install-geoip')
         INSTALL_GEOIP='1'
         ;;
-      'remove')
+      'remove' | '--remove')
         REMOVE='1'
         ;;
       'help')

--- a/install-release.sh
+++ b/install-release.sh
@@ -760,7 +760,7 @@ main() {
   if [[ "$XRAY_RUNNING" -eq '1' ]]; then
     start_xray
   else
-    systemctl enable xray && systemctl start xray
+    systemctl enable xray --now
     if [[ "$?" -eq 0 ]]; then
       echo "info: Enable and start the Xray service"
     else

--- a/install-release.sh
+++ b/install-release.sh
@@ -577,24 +577,24 @@ remove_xray() {
     if [[ -n "$(pidof xray)" ]]; then
       stop_xray
     fi
-    local delet_files=('/usr/local/bin/xray' '/etc/systemd/system/xray.service' '/etc/systemd/system/xray@.service' '/etc/systemd/system/xray.service.d' '/etc/systemd/system/xray@.service.d')
-    [[ -d "$DAT_PATH" ]] && delet_files+=("$DAT_PATH")
+    local delete_files=('/usr/local/bin/xray' '/etc/systemd/system/xray.service' '/etc/systemd/system/xray@.service' '/etc/systemd/system/xray.service.d' '/etc/systemd/system/xray@.service.d')
+    [[ -d "$DAT_PATH" ]] && delete_files+=("$DAT_PATH")
     if [[ "$PURGE" -eq '1' ]]; then
       if [[ -z "$JSONS_PATH" ]]; then
-        delet_files+=("$JSON_PATH")
+        delete_files+=("$JSON_PATH")
       else
-        delet_files+=("$JSONS_PATH")
+        delete_files+=("$JSONS_PATH")
       fi
-      delet_files+=('/var/log/xray')
+      delete_files+=('/var/log/xray')
     fi
     systemctl disable xray
-    if ! ("rm" -r "${delet_files[@]}"); then
+    if ! ("rm" -r "${delete_files[@]}"); then
       echo 'error: Failed to remove Xray.'
       exit 1
     else
-      for i in ${!delet_files[@]}
+      for i in ${!delete_files[@]}
       do
-        echo "removed: ${delet_files[$i]}"
+        echo "removed: ${delete_files[$i]}"
       done
       systemctl daemon-reload
       echo "You may need to execute a command to remove dependent software: $PACKAGE_MANAGEMENT_REMOVE curl unzip"

--- a/install-release.sh
+++ b/install-release.sh
@@ -414,7 +414,7 @@ install_xray() {
   # Install Xray binary to /usr/local/bin/ and $DAT_PATH
   install_file xray
   # If the file exists, geoip.dat and geosite.dat will not be installed or updated
-  if ([[ -f "${DAT_PATH}/geoip.dat" ]] || [[ "$NO_GEOIP" -eq '0' ]]) && [[ ! -f "${DAT_PATH}/.undat" ]]; then
+  if [[ "$NO_GEOIP" -eq '0' ]] && [[ ! -f "${DAT_PATH}/.undat" ]]; then
     install -d "$DAT_PATH"
     install_file geoip.dat
     install_file geosite.dat
@@ -635,7 +635,7 @@ show_help() {
   echo '    -u, --install-user        Install Xray in specified user, e.g, -u root'
   echo '    --reinstall               Reinstall current Xray version'
   echo "    --not-update-service      Don't change service files if they are exist"
-  echo "    --without-geoip           Don't install geoip files if they are not exist"
+  echo "    --without-geoip           Don't install/update geoip files"
   echo '  remove:'
   echo '    --purge                   Remove all the Xray files, include logs, configs, etc'
   echo '  check:'

--- a/install-release.sh
+++ b/install-release.sh
@@ -35,8 +35,8 @@ RELEASE_LATEST=""
 INSTALL_VERSION=""
 # install
 INSTALL='0'
-# install-geoip
-INSTALL_GEOIP='0'
+# install-geodata
+INSTALL_GEODATA='0'
 # remove
 REMOVE='0'
 # help
@@ -47,8 +47,8 @@ CHECK='0'
 FORCE='0'
 # --install-user ?
 INSTALL_USER=""
-# --without-geoip
-NO_GEOIP='0'
+# --without-geodata
+NO_GEODATA='0'
 # --not-update-service
 N_UP_SERVICE='0'
 # --reinstall
@@ -191,8 +191,8 @@ judgment_parameters() {
       'install')
         INSTALL='1'
         ;;
-      'install-geoip')
-        INSTALL_GEOIP='1'
+      'install-geodata')
+        INSTALL_GEODATA='1'
         ;;
       'remove' | '--remove')
         REMOVE='1'
@@ -203,8 +203,8 @@ judgment_parameters() {
       'check')
         CHECK='1'
         ;;
-      '--without-geoip')
-        NO_GEOIP='1'
+      '--without-geodata')
+        NO_GEODATA='1'
         ;;
       '--purge')
         PURGE='1'
@@ -259,9 +259,9 @@ judgment_parameters() {
     esac
     shift
   done
-  if ((INSTALL+INSTALL_GEOIP+HELP+CHECK+REMOVE==0)); then
+  if ((INSTALL+INSTALL_GEODATA+HELP+CHECK+REMOVE==0)); then
     INSTALL='1'
-  elif ((INSTALL+INSTALL_GEOIP+HELP+CHECK+REMOVE>1)); then
+  elif ((INSTALL+INSTALL_GEODATA+HELP+CHECK+REMOVE>1)); then
     echo 'You can only choose one action.'
     exit 1
   fi
@@ -419,11 +419,11 @@ install_xray() {
   # Install Xray binary to /usr/local/bin/ and $DAT_PATH
   install_file xray
   # If the file exists, geoip.dat and geosite.dat will not be installed or updated
-  if [[ "$NO_GEOIP" -eq '0' ]] && [[ ! -f "${DAT_PATH}/.undat" ]]; then
+  if [[ "$NO_GEODATA" -eq '0' ]] && [[ ! -f "${DAT_PATH}/.undat" ]]; then
     install -d "$DAT_PATH"
     install_file geoip.dat
     install_file geosite.dat
-    GEOIP='1'
+    GEODATA='1'
   fi
 
   # Install Xray configuration file to $JSON_PATH
@@ -559,8 +559,8 @@ stop_xray() {
   echo 'info: Stop the Xray service.'
 }
 
-install_geoip() {
-  download_geoip_files() {
+install_geodata() {
+  download_geodata() {
     if ! curl -x "${PROXY}" -R -H 'Cache-Control: no-cache' -o "${dir_tmp}/${2}" "${1}"; then
       echo 'error: Download failed! Please check your network or try again.'
       exit 1
@@ -577,8 +577,8 @@ install_geoip() {
   local file_site='geosite.dat'
   local dir_tmp="$(mktemp -d)"
   [[ ! -f '/usr/local/bin/xray' ]] && echo "warning: Xray was not installed"
-  download_geoip_files $download_link_geoip $file_ip
-  download_geoip_files $download_link_geosite $file_dlc
+  download_geodata $download_link_geoip $file_ip
+  download_geodata $download_link_geosite $file_dlc
   cd "${dir_tmp}" || exit
   for i in "${dir_tmp}"/*.sha256sum; do
     if ! sha256sum -c "${i}"; then
@@ -661,7 +661,7 @@ show_help() {
   echo
   echo 'ACTION:'
   echo '  install                   Install/Update Xray'
-  echo '  install-geoip             Install/Update geoip files only'
+  echo '  install-geodata           Install/Update geoip.dat and geosite.dat only'
   echo '  remove                    Remove Xray'
   echo '  help                      Show help'
   echo '  check                     Check if Xray can be updated'
@@ -676,8 +676,8 @@ show_help() {
   echo '    -u, --install-user        Install Xray in specified user, e.g, -u root'
   echo '    --reinstall               Reinstall current Xray version'
   echo "    --not-update-service      Don't change service files if they are exist"
-  echo "    --without-geoip           Don't install/update geoip files"
-  echo '  install-geoip:'
+  echo "    --without-geodata         Don't install/update geoip.dat and geosite.dat"
+  echo '  install-geodata:'
   echo '    -p, --proxy               Download through a proxy server'
   echo '  remove:'
   echo '    --purge                   Remove all the Xray files, include logs, configs, etc'
@@ -701,7 +701,7 @@ main() {
   [[ "$HELP" -eq '1' ]] && show_help
   [[ "$CHECK" -eq '1' ]] && check_update
   [[ "$REMOVE" -eq '1' ]] && remove_xray
-  [[ "$INSTALL_GEOIP" -eq '1' ]] && install_geoip
+  [[ "$INSTALL_GEODATA" -eq '1' ]] && install_geodata
 
   # Check if the user is effective
   check_install_user
@@ -768,7 +768,7 @@ main() {
   ([[ "$N_UP_SERVICE" -eq '1' ]] && [[ -f '/etc/systemd/system/xray.service' ]]) || install_startup_service_file
   echo 'installed: /usr/local/bin/xray'
   # If the file exists, the content output of installing or updating geoip.dat and geosite.dat will not be displayed
-  if [[ "$GEOIP" -eq '1' ]]; then
+  if [[ "$GEODATA" -eq '1' ]]; then
     echo "installed: ${DAT_PATH}/geoip.dat"
     echo "installed: ${DAT_PATH}/geosite.dat"
   fi


### PR DESCRIPTION
1.修改选项逻辑为
bash install.sh [选项]... 动作
如果没有指定动作，则默认为 install
具体见 help 命令(660行)

2.remove 动作新增选项 --purge  ，将删除配置文件和log

3.install 动作新增选项 --without-geodata ，不需要再 .undat 了

4.现脚本安装完后自动执行 `systemctl enable xray --new`，卸载后自动执行`systemctl disable xray`
依据是，使用apt/yum/dnf安装的软件，基本都是这样子的。我也觉得这样更合理