### PR TITLE
Fix mips64 Little Endian checking

### DIFF
--- a/install-release.sh
+++ b/install-release.sh
@@ -151,6 +151,7 @@ identify_the_operating_system_and_architecture() {
         ;;
       'mips64')
         MACHINE='mips64'
+	lscpu | grep -q "Little Endian" && MACHINE='mips64le'
         ;;
       'mips64le')
         MACHINE='mips64le'

--- a/install-release.sh
+++ b/install-release.sh
@@ -151,7 +151,7 @@ identify_the_operating_system_and_architecture() {
         ;;
       'mips64')
         MACHINE='mips64'
-	lscpu | grep -q "Little Endian" && MACHINE='mips64le'
+        lscpu | grep -q "Little Endian" && MACHINE='mips64le'
         ;;
       'mips64le')
         MACHINE='mips64le'


### PR DESCRIPTION
修正mips64le检查，在基于mips64le的linux系统上，运行`uname -m`结果为`mips64`。需要进一步去判断是大端还是小端