### PR TITLE
Fix verison check for 1.6.6-2

### DIFF
--- a/install-release.sh
+++ b/install-release.sh
@@ -407,42 +407,7 @@ get_latest_version() {
 }
 
 version_gt() {
-  # compare two version
-  # 0: $1 >  $2
-  # 1: $1 <= $2
-
-  if [[ "$1" != "$2" ]]; then
-    local temp_1_version_number="${1#v}"
-    local temp_1_major_version_number="${temp_1_version_number%%.*}"
-    local temp_1_minor_version_number
-    temp_1_minor_version_number="$(echo "$temp_1_version_number" | awk -F '.' '{print $2}')"
-    local temp_1_minimunm_version_number="${temp_1_version_number##*.}"
-    # shellcheck disable=SC2001
-    local temp_2_version_number="${2#v}"
-    local temp_2_major_version_number="${temp_2_version_number%%.*}"
-    local temp_2_minor_version_number
-    temp_2_minor_version_number="$(echo "$temp_2_version_number" | awk -F '.' '{print $2}')"
-    local temp_2_minimunm_version_number="${temp_2_version_number##*.}"
-    if [[ "$temp_1_major_version_number" -gt "$temp_2_major_version_number" ]]; then
-      return 0
-    elif [[ "$temp_1_major_version_number" -eq "$temp_2_major_version_number" ]]; then
-      if [[ "$temp_1_minor_version_number" -gt "$temp_2_minor_version_number" ]]; then
-        return 0
-      elif [[ "$temp_1_minor_version_number" -eq "$temp_2_minor_version_number" ]]; then
-        if [[ "$temp_1_minimunm_version_number" -gt "$temp_2_minimunm_version_number" ]]; then
-          return 0
-        else
-          return 1
-        fi
-      else
-        return 1
-      fi
-    else
-      return 1
-    fi
-  elif [[ "$1" == "$2" ]]; then
-    return 1
-  fi
+  test "$(echo -e "$1\\n$2" | sort -V | head -n 1)" != "$1"
 }
 
 download_xray() {


### PR DESCRIPTION
脚本无法识别出 v1.6.6-2 是比 v1.6.6 更新的版本，之前已经安装了 v1.6.6 的用户，即使使用 --beta 选项也无法更新到 v1.6.6-2 版本。

原因是原来的脚本是分将版本号分为三个数字 1、6、6，依次进行比对，所以识别出来 `v1.6.6` 和 `v1.6.6-2` 是一样的版本。这部分是从上游v2fly仓库延续过来的代码，其实不用这么麻烦，类Unix系统有提供一个 sort -V 命令专门进行版本比较。

但是现在也有问题，因为更新到了 v1.6.6-2 版本后，运行 Xray 程序查询版本号`xray version`仍然显示 v1.6.6 ，这就导致即使升到了 v1.6.6-2 ，运行 `bash xray-install.sh install --beta` 仍然会继续安装一遍 v1.6.6-2，这可能需要 @yuhan6665 在Xray那边同步修改Xray主程序版本号的显示