### PR TITLE
Correct command for installing pre-release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Notice: Xray will NOT log to `/var/log/xray/*.log` by default. Configure `"log"`
 **Install & Upgrade Xray-core to a pre-release version**
 
 ```
-# bash -c "$(curl -L https://github.com/XTLS/Xray-install/raw/main/install-release.sh)" @ install --version 1.5.8
+# bash -c "$(curl -L https://github.com/XTLS/Xray-install/raw/main/install-release.sh)" @ install --beta
 ```
 
 **Install & Upgrade Xray-core and geodata with `User=root`, which will overwrite `User` in existing service files**


### PR DESCRIPTION
Former command for installing pre-release version will install version 1.5.8 instead of the latest pre-release version.