### PR TITLE
[Feature Addition] Introducing the --logrotate Option for Xray's Enhanced Log Rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ Notice: Xray will NOT log to `/var/log/xray/*.log` by default. Configure `"log"`
 # bash -c "$(curl -L https://github.com/XTLS/Xray-install/raw/main/install-release.sh)" @ install --beta
 ```
 
+**Install & Upgrade Xray-core and geodata with `logrotate`**
+
+```
+# bash -c "$(curl -L https://github.com/XTLS/Xray-install/raw/main/install-release.sh)" @ install --logrotate
+```
+```
+installed: /etc/systemd/system/logrotate@.service
+installed: /etc/systemd/system/logrotate@.timer
+
+installed: /etc/logrotate.d/xray
+```
+
 **Install & Upgrade Xray-core and geodata with `User=root`, which will overwrite `User` in existing service files**
 
 ```

--- a/install-release.sh
+++ b/install-release.sh
@@ -626,7 +626,6 @@ stop_xray() {
 
 install_with_logrotate() {
   install_software 'logrotate' 'logrotate'
-  check_install_user
   if [[ -z "$LOGROTATE_TIME" ]]; then
   LOGROTATE_TIME="00:00:00"
   fi
@@ -655,20 +654,10 @@ EOF
       LOGROTATE_DIR='1'
   fi
   cat << EOF > /etc/logrotate.d/xray
-/var/log/xray/access.log {
+/var/log/xray/*.log {
     daily
     missingok
-    rotate 30
-    compress
-    delaycompress
-    notifempty
-    create 0600 $INSTALL_USER_UID $INSTALL_USER_GID
-}
-
-/var/log/xray/error.log {
-    daily
-    missingok
-    rotate 30
+    rotate 7
     compress
     delaycompress
     notifempty
@@ -824,9 +813,12 @@ main() {
   [[ "$CHECK" -eq '1' ]] && check_update
   [[ "$REMOVE" -eq '1' ]] && remove_xray
   [[ "$INSTALL_GEODATA" -eq '1' ]] && install_geodata
-  [[ "$LOGROTATE" -eq '1' ]] && install_with_logrotate
+
   # Check if the user is effective
   check_install_user
+
+  # Check Logrotate after Check User
+  [[ "$LOGROTATE" -eq '1' ]] && install_with_logrotate
 
   # Two very important variables
   TMP_DIRECTORY="$(mktemp -d)"

--- a/install-release.sh
+++ b/install-release.sh
@@ -626,6 +626,7 @@ stop_xray() {
 
 install_with_logrotate() {
   install_software 'logrotate' 'logrotate'
+  check_install_user
   if [[ -z "$LOGROTATE_TIME" ]]; then
   LOGROTATE_TIME="00:00:00"
   fi
@@ -661,7 +662,7 @@ EOF
     compress
     delaycompress
     notifempty
-    create 0600 nobody nobody
+    create 0600 $INSTALL_USER_UID $INSTALL_USER_GID
 }
 
 /var/log/xray/error.log {
@@ -671,7 +672,7 @@ EOF
     compress
     delaycompress
     notifempty
-    create 0600 nobody nobody
+    create 0600 $INSTALL_USER_UID $INSTALL_USER_GID
 }
 EOF
   LOGROTATE_FIN='1'


### PR DESCRIPTION
With the newly added `--logrotate` option, Xray installations now offer enhanced log rotation using Logrotate. When this option is specified during the installation process, Xray will automatically integrate with Logrotate for seamless log management. Logrotate ensures that Xray's log files are regularly rotated, compressed, and efficiently managed to prevent storage overflow and maintain historical logs for future analysis. By default, Xray will utilize Logrotate, providing users with an organized and optimized approach to log rotation.

Usage:
```
install-release.sh --logrotate $time
```
$time can be in the format of `12:34:56`