### PR TITLE
Fix: Check if logrotate@.timer exists before executing stop and disable. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Notice: Xray will NOT log to `/var/log/xray/*.log` by default. Configure `"log"`
 # bash -c "$(curl -L https://github.com/XTLS/Xray-install/raw/main/install-release.sh)" @ install --beta
 ```
 
-**Install & Upgrade Xray-core and geodata with `logrotate`**
+**Install & Upgrade Xray-core and geodata with `logrotate`, `$time` can be in the format of 12:34:56**
 
 ```
-# bash -c "$(curl -L https://github.com/XTLS/Xray-install/raw/main/install-release.sh)" @ install --logrotate
+# bash -c "$(curl -L https://github.com/XTLS/Xray-install/raw/main/install-release.sh)" @ install --logrotate $time
 ```
 ```
 installed: /etc/systemd/system/logrotate@.service

--- a/install-release.sh
+++ b/install-release.sh
@@ -735,7 +735,13 @@ remove_xray() {
       [[ -f '/etc/systemd/system/logrotate@.timer' ]] && delete_files+=('/etc/systemd/system/logrotate@.timer')
     fi
     systemctl disable xray
-    systemctl disable logrotate@xray.timer
+    if [[ -f '/etc/systemd/system/logrotate@.timer' ]] ; then
+      if ! systemctl stop logrotate@xray.timer && systemctl disable logrotate@xray.timer ; then
+        echo 'error: Stopping and disabling the logrotate service failed.'
+        exit 1
+      fi
+      echo 'info: Stop and disable the logrotate service.'
+    fi
     if ! ("rm" -r "${delete_files[@]}"); then
       echo 'error: Failed to remove Xray.'
       exit 1
@@ -787,7 +793,7 @@ show_help() {
   echo "    --no-update-service       Don't change service files if they are exist"
   echo "    --without-geodata         Don't install/update geoip.dat and geosite.dat"
   echo "    --without-logfiles        Don't install /var/log/xray"
-  echo "    --logrotate               Install with logrotate"
+  echo "    --logrotate [time]        Install with logrotate. [time] can be in the format of 12:34:56"
   echo '  install-geodata:'
   echo '    -p, --proxy               Download through a proxy server'
   echo '  remove:'


### PR DESCRIPTION
* Check if logrotate@.timer exists before executing stop and disable. 
https://github.com/XTLS/Xray-install/pull/62#issuecomment-1661527981

Add:
* Instructions on how to use `logrotate` in the README.md and `help` command.