### PR TITLE
Update xray

### DIFF
--- a/alpinelinux/init.d/xray
+++ b/alpinelinux/init.d/xray
@@ -9,7 +9,6 @@ respawn_max=2
 respawn_period=600
 
 pidfile="/run/${RC_SVCNAME}.pid"
-rc_ulimit="-n 1024000 -u 1024000"
 capabilities="^cap_net_bind_service,^cap_net_admin,^cap_net_raw"
 extra_commands="checkconfig"
 
@@ -28,7 +27,7 @@ depend() {
 
 checkconfig() {
 	export $env
-	$command $command_args -test
+	su ${command_user%:*} -s /bin/sh -c "$command $command_args -test"
 	eend $?
 }
 


### PR DESCRIPTION
删除rc_ulimit="-n 1024000 -u 1024000"
有些lxc nat小鸡没有权限，应该也不是必须的

$command $command_args -test修改为su ${command_user%:*} -s /bin/sh -c "$command $command_args -test"
如果不加su ${command_user%:*}，当log文件不存在的时候，会以root身份创建log文件，导致权限错误
